### PR TITLE
Retry demo homepage fetches on 5xx errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "beautifulsoup4>=4.14.3",
     "pydantic>=2.13.0",
     "python-slugify>=8.0.4",
+    "stamina>=26.1.0",
 ]
 
 [project.urls]

--- a/src/jg/hen/core.py
+++ b/src/jg/hen/core.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import httpx
+import stamina
 from githubkit import GitHub
 from githubkit.exception import RequestFailed
 
@@ -112,12 +113,7 @@ async def check_profile_url(
 
                 if homepage_url := repo.homepage:
                     logger.debug(f"Fetching homepage for {repo_slug}: {homepage_url}")
-                    try:
-                        demo_result = await http.get(
-                            homepage_url, follow_redirects=True, timeout=10.0
-                        )
-                    except Exception as e:
-                        demo_result = e
+                    demo_result = await fetch_demo(http, homepage_url)
             else:
                 # For efficiency, ignore downloading additional details
                 # for archived repos which are not pinned
@@ -162,6 +158,28 @@ def get_pin_index(repo_slug: str, pins_index: list[str]) -> int | None:
 
 def is_external_repo(repo_owner: str, username: str) -> bool:
     return repo_owner.lower() != username.lower()
+
+
+def is_demo_server_error(exc: BaseException) -> bool:
+    return isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code >= 500
+
+
+@stamina.retry(on=is_demo_server_error, attempts=3)
+async def _fetch_demo(http: httpx.AsyncClient, homepage_url: str) -> httpx.Response:
+    response = await http.get(homepage_url, follow_redirects=True, timeout=10.0)
+    response.raise_for_status()
+    return response
+
+
+async def fetch_demo(
+    http: httpx.AsyncClient, homepage_url: str
+) -> httpx.Response | Exception:
+    try:
+        return await _fetch_demo(http, homepage_url)
+    except httpx.HTTPStatusError as e:
+        return e.response
+    except Exception as e:
+        return e
 
 
 def get_demo_url(result: httpx.Response | Exception | None) -> str | None:

--- a/src/jg/hen/core.py
+++ b/src/jg/hen/core.py
@@ -167,7 +167,7 @@ def is_demo_server_error(exc: BaseException) -> bool:
 @stamina.retry(on=is_demo_server_error, attempts=3)
 async def _fetch_demo(http: httpx.AsyncClient, homepage_url: str) -> httpx.Response:
     response = await http.get(homepage_url, follow_redirects=True, timeout=10.0)
-    response.raise_for_status()
+    response.raise_for_status()  # this must happen to trigger stamina retries
     return response
 
 

--- a/tests/test_core_fetch_demo.py
+++ b/tests/test_core_fetch_demo.py
@@ -12,10 +12,9 @@ def no_backoff():
     stamina.set_testing(False)
 
 
-TransportWithRequests = tuple[httpx.MockTransport, list[httpx.Request]]
-
-
-def responses_transport(*status_codes: int) -> TransportWithRequests:
+def responses_transport(
+    *status_codes: int,
+) -> tuple[httpx.MockTransport, list[httpx.Request]]:
     codes = iter(status_codes)
     requests = []
 

--- a/tests/test_core_fetch_demo.py
+++ b/tests/test_core_fetch_demo.py
@@ -1,0 +1,81 @@
+import httpx
+import pytest
+import stamina
+
+from jg.hen.core import fetch_demo
+
+
+@pytest.fixture(autouse=True)
+def no_backoff():
+    stamina.set_testing(True, attempts=3)
+    yield
+    stamina.set_testing(False)
+
+
+def responses_transport(
+    *status_codes: int,
+) -> tuple[httpx.MockTransport, list[httpx.Request]]:
+    codes = iter(status_codes)
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(next(codes), request=request)
+
+    return httpx.MockTransport(handler), requests
+
+
+@pytest.mark.asyncio
+async def test_fetch_demo_succeeds_on_first_try():
+    transport, requests = responses_transport(200)
+    async with httpx.AsyncClient(transport=transport) as http:
+        result = await fetch_demo(http, "https://example.com")
+
+    assert isinstance(result, httpx.Response)
+    assert result.status_code == 200
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_demo_retries_on_server_error_then_succeeds():
+    transport, requests = responses_transport(503, 502, 200)
+    async with httpx.AsyncClient(transport=transport) as http:
+        result = await fetch_demo(http, "https://example.com")
+
+    assert isinstance(result, httpx.Response)
+    assert result.status_code == 200
+    assert len(requests) == 3
+
+
+@pytest.mark.asyncio
+async def test_fetch_demo_gives_up_after_repeated_server_errors():
+    transport, requests = responses_transport(503, 503, 503)
+    async with httpx.AsyncClient(transport=transport) as http:
+        result = await fetch_demo(http, "https://example.com")
+
+    assert isinstance(result, httpx.Response)
+    assert result.status_code == 503
+    assert len(requests) == 3
+
+
+@pytest.mark.asyncio
+async def test_fetch_demo_does_not_retry_on_client_error():
+    transport, requests = responses_transport(404)
+    async with httpx.AsyncClient(transport=transport) as http:
+        result = await fetch_demo(http, "https://example.com")
+
+    assert isinstance(result, httpx.Response)
+    assert result.status_code == 404
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_demo_does_not_retry_on_connection_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("nope", request=request)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http:
+        result = await fetch_demo(http, "https://example.com")
+
+    assert isinstance(result, httpx.ConnectError)

--- a/tests/test_core_fetch_demo.py
+++ b/tests/test_core_fetch_demo.py
@@ -12,9 +12,10 @@ def no_backoff():
     stamina.set_testing(False)
 
 
-def responses_transport(
-    *status_codes: int,
-) -> tuple[httpx.MockTransport, list[httpx.Request]]:
+TransportWithRequests = tuple[httpx.MockTransport, list[httpx.Request]]
+
+
+def responses_transport(*status_codes: int) -> TransportWithRequests:
     codes = iter(status_codes)
     requests = []
 

--- a/uv.lock
+++ b/uv.lock
@@ -253,6 +253,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pydantic" },
     { name = "python-slugify" },
+    { name = "stamina" },
 ]
 
 [package.dev-dependencies]
@@ -274,6 +275,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.13.0" },
     { name = "python-slugify", specifier = ">=8.0.4" },
+    { name = "stamina", specifier = ">=26.1.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -618,6 +620,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "stamina"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/bd/b2f71ae14368a066f103d182f25bbc6c3bf4aa695889f3ed3cba026d6f36/stamina-26.1.0.tar.gz", hash = "sha256:0214d05fdf5102c518194a4aac7520ce53cf660550ae3b940701aad88cf50c17", size = 568171, upload-time = "2026-04-13T17:44:31.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/f0/1ff90a1d1dd02de23feafdf9dffaecef3958348be5c192df56670ccb4f86/stamina-26.1.0-py3-none-any.whl", hash = "sha256:62e06829bec87c06d4cafde520b32a6097d1017c378a9eb63253c5bf5ebbbb88", size = 18508, upload-time = "2026-04-13T17:44:29.545Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #140.

## Problem

Demos hosted on flaky servers occasionally return transient 5xx errors. A single failed request was enough to mark a working demo as broken, which in turn caused repeated false-positive profile demotions downstream in `eggtray` (e.g. juniorguru/eggtray#387, and 5 similar issues before it). `eggtray` has no strike-counting infra to smooth this out, so `hen` should be more robust about it.

## Fix

Introduce `fetch_demo()` in `jg.hen.core`, which wraps the homepage request with [`stamina`](https://github.com/hynek/stamina) retries:

- Retries **only** on server errors (5xx), up to 3 attempts, with exponential backoff + jitter.
- Fails fast on client errors (4xx) and connection errors — a genuinely broken demo still gets flagged immediately, no wasted retries.
- Returns the same `httpx.Response | Exception` shape the rest of the pipeline already expects, so `get_demo_url` and the `has_pinned_repo_with_working_demo` rule are unchanged.

The retry predicate is a small pure function (`is_demo_server_error`), keeping cyclomatic complexity low and the inline `try/except` out of `check_profile_url`.

## Tests

`tests/test_core_fetch_demo.py` drives `fetch_demo` through an in-memory `httpx.MockTransport` returning real `httpx.Response` objects — no `unittest.mock`, no monkeypatching. Covers: success on first try, retry-then-succeed on 5xx, giving up after repeated 5xx, no retry on 4xx, and no retry on connection errors. `stamina.set_testing()` removes backoff delays so the suite stays fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7xZUTQL5t35upAvGrjGZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7xZUTQL5t35upAvGrjGZs)_