### PR TITLE
Unit-test all pure functions in lib

### DIFF
--- a/tests/test_lib_demo.py
+++ b/tests/test_lib_demo.py
@@ -2,7 +2,17 @@ import httpx
 import pytest
 import stamina
 
-from jg.hen.lib.demo import fetch_demo
+from jg.hen.lib.demo import fetch_demo, get_demo_url, is_demo_server_error
+
+
+def status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://example.com")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError("boom", request=request, response=response)
+
+
+def response(status_code: int, url: str = "https://demo.example.com") -> httpx.Response:
+    return httpx.Response(status_code, request=httpx.Request("GET", url))
 
 
 @pytest.fixture(autouse=True)
@@ -79,3 +89,46 @@ async def test_fetch_demo_does_not_retry_on_connection_error():
         result = await fetch_demo(http, "https://example.com")
 
     assert isinstance(result, httpx.ConnectError)
+
+
+@pytest.mark.parametrize(
+    "exc, expected",
+    [
+        pytest.param(status_error(500), True, id="500-internal-error"),
+        pytest.param(status_error(502), True, id="502-bad-gateway"),
+        pytest.param(status_error(503), True, id="503-unavailable"),
+        pytest.param(status_error(599), True, id="599-upper-bound"),
+        pytest.param(status_error(400), False, id="400-bad-request"),
+        pytest.param(status_error(404), False, id="404-not-found"),
+        pytest.param(status_error(499), False, id="499-just-below-5xx"),
+        pytest.param(httpx.ConnectError("nope"), False, id="connect-error"),
+        pytest.param(ValueError("nope"), False, id="non-httpx-error"),
+    ],
+)
+def test_is_demo_server_error(exc: BaseException, expected: bool):
+    assert is_demo_server_error(exc) is expected
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        pytest.param(None, id="none"),
+        pytest.param(httpx.ConnectError("nope"), id="exception"),
+        pytest.param(response(404), id="client-error"),
+        pytest.param(response(500), id="server-error"),
+    ],
+)
+def test_get_demo_url_returns_none(result: httpx.Response | Exception | None):
+    assert get_demo_url(result) is None
+
+
+@pytest.mark.parametrize(
+    "status_code",
+    [
+        pytest.param(200, id="200-ok"),
+        pytest.param(204, id="204-no-content"),
+    ],
+)
+def test_get_demo_url_returns_url_for_success(status_code: int):
+    result = response(status_code, "https://demo.example.com")
+    assert get_demo_url(result) == "https://demo.example.com"

--- a/tests/test_lib_readme.py
+++ b/tests/test_lib_readme.py
@@ -6,11 +6,10 @@ from jg.hen.lib.readme import extract_image_urls, extract_title, make_urls_absol
 
 
 @pytest.mark.asyncio
-async def test_extract_image_urls_html_fixture(fixtures_dir: Path):
+async def test_extract_image_urls_reads_html_img_tags(fixtures_dir: Path):
     readme = (fixtures_dir / "readme-html-img.md").read_text()
-    urls = await extract_image_urls(readme)
 
-    assert urls == [
+    assert await extract_image_urls(readme) == [
         "https://github.com/PavlaBerankova/kulturmapa/assets/107038196/353c0018-cdf6-48f7-befa-ead8fe27ec6f",
         "https://github.com/PavlaBerankova/kulturmapa/assets/107038196/30806427-0883-403f-aabe-0d7fb450d1f1",
         "https://github.com/PavlaBerankova/kulturmapa/assets/107038196/213f3528-635a-45a5-8ea7-46218ec0e0a2",
@@ -24,11 +23,10 @@ async def test_extract_image_urls_html_fixture(fixtures_dir: Path):
 
 
 @pytest.mark.asyncio
-async def test_extract_image_urls_relative(fixtures_dir: Path):
+async def test_extract_image_urls_keeps_sources_verbatim(fixtures_dir: Path):
     readme = (fixtures_dir / "readme-relative-link.md").read_text()
-    urls = await extract_image_urls(readme)
 
-    assert urls == [
+    assert await extract_image_urls(readme) == [
         "./public/img/mockup.png",
         "https://camo.githubusercontent.com/c31126fcb6f4cb77220a3916a05cfaf4a86500593794dbdc2c7a6746c7f70249/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f52656163742d31382e332e312d3631444146423f6c6f676f3d7265616374",
         "https://camo.githubusercontent.com/d624bbb16055b6e962f0bc6e9a44bbf96343f3a6999eba9ab0fea22a3c77eee4/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f566974652d362e302e332d3634364346463f6c6f676f3d76697465",
@@ -38,78 +36,76 @@ async def test_extract_image_urls_relative(fixtures_dir: Path):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "markup, expected",
+    "markup",
     [
-        ("<img alt='logo'>", []),
-        ("<img src='' alt='empty'>", []),
-        (None, []),
-        ("", []),
+        pytest.param(None, id="none"),
+        pytest.param("", id="empty"),
+        pytest.param("<img alt='logo'>", id="img-without-src"),
+        pytest.param("<img src='' alt='empty'>", id="img-with-empty-src"),
+        pytest.param("<p>No images here</p>", id="no-img-tag"),
     ],
 )
-async def test_extract_image_urls_handles_missing_sources(
-    markup: str | None, expected: list[str]
-):
-    assert await extract_image_urls(markup) == expected
+async def test_extract_image_urls_returns_empty(markup: str | None):
+    assert await extract_image_urls(markup) == []
 
 
 @pytest.mark.asyncio
-async def test_extract_title_returns_none_for_missing_heading():
-    assert await extract_title(None) is None
-    assert await extract_title("") is None
-    assert await extract_title("<p>No heading here</p>") is None
-
-
-@pytest.mark.asyncio
-async def test_extract_title_reads_primary_heading():
-    readme = "<article><h1>  My Project </h1><p>Welcome</p></article>"
-
-    assert await extract_title(readme) == "My Project"
-
-
-@pytest.mark.asyncio
-async def test_extract_title_only_uses_h1_not_h2():
-    readme = "<section><h2>Secondary</h2><h1>Primary</h1></section>"
-
-    assert await extract_title(readme) == "Primary"
-
-
-@pytest.mark.asyncio
-async def test_extract_title_ignores_h2_only():
-    readme = "<section><h2>Only Secondary</h2><p>Some content</p></section>"
-
-    assert await extract_title(readme) is None
+@pytest.mark.parametrize(
+    "readme, expected",
+    [
+        pytest.param(None, None, id="none"),
+        pytest.param("", None, id="empty"),
+        pytest.param("<p>No heading here</p>", None, id="no-heading"),
+        pytest.param("<h2>Only secondary</h2>", None, id="h2-without-h1"),
+        pytest.param(
+            "<article><h1>  My Project </h1><p>Welcome</p></article>",
+            "My Project",
+            id="strips-surrounding-whitespace",
+        ),
+        pytest.param(
+            "<section><h2>Secondary</h2><h1>Primary</h1></section>",
+            "Primary",
+            id="prefers-h1-over-h2",
+        ),
+    ],
+)
+async def test_extract_title(readme: str | None, expected: str | None):
+    assert await extract_title(readme) == expected
 
 
 @pytest.mark.parametrize(
-    "urls, expected",
+    "url, expected",
     [
-        ([], []),
-        (
-            ["https://example.com/pic3.png"],
-            ["https://example.com/pic3.png"],
+        pytest.param(
+            "https://example.com/pic3.png",
+            "https://example.com/pic3.png",
+            id="absolute-url-unchanged",
         ),
-        (
-            ["./public/img/mockup.png"],
-            ["https://raw.githubusercontent.com/user/repo/main/public/img/mockup.png"],
+        pytest.param(
+            "./public/img/mockup.png",
+            "https://raw.githubusercontent.com/user/repo/main/public/img/mockup.png",
+            id="dot-relative",
         ),
-        (
-            ["modern-browser-mockup.png"],
-            [
-                "https://raw.githubusercontent.com/user/repo/main/modern-browser-mockup.png"
-            ],
+        pytest.param(
+            "modern-browser-mockup.png",
+            "https://raw.githubusercontent.com/user/repo/main/modern-browser-mockup.png",
+            id="bare-filename",
         ),
-        (
-            ["Nu,_pogodi!_logo.png"],
-            ["https://raw.githubusercontent.com/user/repo/main/Nu,_pogodi!_logo.png"],
+        pytest.param(
+            "Nu,_pogodi!_logo.png",
+            "https://raw.githubusercontent.com/user/repo/main/Nu,_pogodi!_logo.png",
+            id="special-characters",
         ),
-        (
-            ["docs/bottom-keyboard-clone.png"],
-            [
-                "https://raw.githubusercontent.com/user/repo/main/docs/bottom-keyboard-clone.png"
-            ],
+        pytest.param(
+            "docs/bottom-keyboard-clone.png",
+            "https://raw.githubusercontent.com/user/repo/main/docs/bottom-keyboard-clone.png",
+            id="subdirectory",
         ),
     ],
 )
-def test_make_urls_absolute(urls: list[str], expected: list[str]):
-    absolute_urls = make_urls_absolute(urls, "user", "repo", "main")
-    assert absolute_urls == expected
+def test_make_urls_absolute(url: str, expected: str):
+    assert make_urls_absolute([url], "user", "repo", "main") == [expected]
+
+
+def test_make_urls_absolute_empty_list():
+    assert make_urls_absolute([], "user", "repo", "main") == []


### PR DESCRIPTION
## Why

Follow-up to #142. Now that the pure content helpers live in `jg.hen.lib`, this adds direct unit tests for **every pure function** there, as isolated named cases with one assertion each.

## Coverage added

**`lib/demo.py`** — previously only `fetch_demo` was exercised (via the mock-transport tests); its two pure helpers had no direct tests:
- `is_demo_server_error` — 5xx → `True`, 4xx and the 499/500 boundary → `False`, plus non-`HTTPStatusError` inputs (`ConnectError`, `ValueError`) → `False`.
- `get_demo_url` — `None`, an exception, and 4xx/5xx responses → `None`; 2xx responses → the URL string.

Both build **real `httpx.Response` / `httpx.HTTPStatusError` objects** via tiny local factories — no mocks.

**`lib/readme.py`** — the functions were already tested; this reshapes them into the same clean style and rounds out the edges:
- `extract_title` and `make_urls_absolute` folded into `pytest.param(..., id=...)` cases (one assert per case), so each scenario shows up as its own named test.
- `extract_image_urls` keeps the two README fixture tests and gains an explicit `no-img-tag` empty case.

## Result

`pytest` goes from 56 → 74 passing; ruff clean. No production code changed — tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7xZUTQL5t35upAvGrjGZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7xZUTQL5t35upAvGrjGZs)_