### PR TITLE
Warn about missing public email

### DIFF
--- a/src/jg/hen/rules/has_email.py
+++ b/src/jg/hen/rules/has_email.py
@@ -1,0 +1,17 @@
+from githubkit.rest import PublicUser
+
+from jg.hen.models import Status
+from jg.hen.signals import RuleResult, on_profile, rule
+
+
+@rule(
+    on_profile,
+    "https://junior.guru/handbook/github-profile/#vypln-si-zakladni-udaje",
+)
+async def has_email(user: PublicUser) -> RuleResult:
+    if user.email:
+        return (Status.DONE, f"E-mail máš vyplněný: {user.email}")
+    return (
+        Status.WARNING,
+        "Doplň si veřejný e-mail, ať tě zaměstnavatelé mohou spolehlivěji kontaktovat.",
+    )

--- a/tests/test_rule_has_email.py
+++ b/tests/test_rule_has_email.py
@@ -1,0 +1,26 @@
+import pytest
+from githubkit.rest import PublicUser
+
+from jg.hen.models import Status
+from jg.hen.rules.has_email import has_email
+
+
+@pytest.mark.asyncio
+async def test_rule_has_email_done(user: PublicUser):
+    user.email = "mail@honzajavorek.cz"
+
+    result = await has_email(None, user=user)
+
+    assert result
+    assert result.status == Status.DONE
+    assert "mail@honzajavorek.cz" in result.message
+
+
+@pytest.mark.asyncio
+async def test_rule_has_email_warning(user: PublicUser):
+    user.email = None
+
+    result = await has_email(None, user=user)
+
+    assert result
+    assert result.status == Status.WARNING


### PR DESCRIPTION
Closes #134.

## Why

HR feedback on junior.guru/candidates reports that a public email is the most reliable way to reach candidates (3/3 emailed replied, LinkedIn was weaker), and they'd love every candidate to have one in their profile. So flag profiles that expose no public email.

## What

- **`rules/has_email.py`** — a new `on_profile` rule mirroring `has_name` / `has_bio`:
  - email present → `DONE`
  - email missing → `WARNING` (deliberately *not* `ERROR` — where to draw the privacy line is a personal choice, so we nudge rather than demand)
- **`tests/test_rule_has_email.py`** — done + warning cases, modelled on `test_rule_has_linkedin.py`.

The rule is auto-discovered by `load_receivers` (verified it registers on `on_profile`); no wiring needed. 78 tests pass, ruff clean.

## Related

The handbook section this rule links to doesn't yet mention email — I'm opening a small companion PR to `honzajavorek/junior.guru` adding a sentence there explaining the reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7xZUTQL5t35upAvGrjGZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7xZUTQL5t35upAvGrjGZs)_